### PR TITLE
Changed to attach to disk if it exist

### DIFF
--- a/lib/vagrant/newdisk/actions.rb
+++ b/lib/vagrant/newdisk/actions.rb
@@ -23,7 +23,7 @@ module Vagrant
             env[:ui].info "call newdisk: size = #{size}, path = #{path}"
 
             if File.exist? path
-              env[:ui].info "skip newdisk - already exists: #{path}"
+              attach_disk(@machine.provider.driver, path)
             else
               new_disk(env, path, size)
               env[:ui].success "done newdisk: size = #{size}, path = #{path}"


### PR DESCRIPTION
This changes make it possible to take over the home directory by
moving the new disk, even when provisioning,
when using the new disk as the home directory.
Without attachment, even if there is a disk image like new.vdi,
it does not recognize the disk.